### PR TITLE
fix storage key is missing in azure scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ The following prerequisites are required to use this application. Please ensure 
 - [Java 17 or later](https://learn.microsoft.com/java/openjdk/install)
 - [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
 - An Azure subscription with access granted to Azure OpenAI (see more [here](https://customervoice.microsoft.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbR7en2Ais5pxKtso_Pz4b1_xUOFA5Qk1UWDRBMjg0WFhPMkIzTzhKQ1dWNyQlQCN0PWcu))
+- [Powershell 7](https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.3) if you use windows
 
 ### Quickstart
 
@@ -258,7 +259,7 @@ This quickstart will show you how to authenticate on Azure, initialize using a t
 # Log in to azd. Only required once per-install.
 azd auth login
 
-# Enable Azure Spring Apps feature for AZD
+# Enable Azure Spring Apps feature for AZD. Only required once per-install.
 azd config set alpha.springapp on
 
 # First-time project setup. Initialize a project in the current directory, using this template. 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -104,3 +104,4 @@ module springApps 'modules/springapps/springapps.bicep' = {
 }
 
 output STORAGE_ACCOUNT_NAME string = '${storageAccountName}'
+output STORAGE_ACCOUNT_KEY string = '${storage.outputs.storageAccountKey}'

--- a/infra/modules/storage/storage.bicep
+++ b/infra/modules/storage/storage.bicep
@@ -25,3 +25,5 @@ resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2022-0
     enabledProtocols: 'SMB'
   }
 }
+
+output storageAccountKey string = storage.listKeys().keys[0].value

--- a/scripts/prepdocs.ps1
+++ b/scripts/prepdocs.ps1
@@ -14,4 +14,5 @@ if (-not(Test-Path -Path $file -PathType Leaf)) {
 else {
     Write-Host "The file [$file] already exists."
 }
-az storage file upload -s vectorstore --source $file --account-name $Env:STORAGE_ACCOUNT_NAME --subscription $Env:AZURE_SUBSCRIPTION_ID
+az storage file upload -s vectorstore --source $file --account-name $Env:STORAGE_ACCOUNT_NAME --subscription $Env:AZURE_SUBSCRIPTION_ID --account-key $Env:STORAGE_ACCOUNT_KEY
+

--- a/scripts/prepdocs.sh
+++ b/scripts/prepdocs.sh
@@ -9,5 +9,5 @@ else
   echo "The file $FILE has been downloaded."
 fi
 
-az storage file upload -s vectorstore --source $FILE --account-name $STORAGE_ACCOUNT_NAME --subscription $AZURE_SUBSCRIPTION_ID
+az storage file upload -s vectorstore --source $FILE --account-name $STORAGE_ACCOUNT_NAME --subscription $AZURE_SUBSCRIPTION_ID --account-key $STORAGE_ACCOUNT_KEY
 


### PR DESCRIPTION
This pr is to fix that the storage key is not exposed an azd env var so that when running scripts to upload vector store, credential is lacking.